### PR TITLE
Fix error when unnecessary http params are passed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     dotenv (2.6.0)
     dry-auto_inject (0.6.0)
       dry-container (>= 0.3.4)
-    dry-configurable (0.8.0)
+    dry-configurable (0.8.2)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
     dry-container (0.7.0)
@@ -398,4 +398,4 @@ RUBY VERSION
    ruby 2.5.0p0
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/apps/web/controllers/vacancies/index.rb
+++ b/apps/web/controllers/vacancies/index.rb
@@ -14,6 +14,10 @@ module Web
         expose :vacancies
         expose :pager
 
+        params do
+          required(:page).filled
+        end
+
         def call(params)
           result = operation.call(params)
 

--- a/spec/web/controllers/vacancies/index_spec.rb
+++ b/spec/web/controllers/vacancies/index_spec.rb
@@ -49,5 +49,11 @@ RSpec.describe Web::Controllers::Vacancies::Index, type: :action do
         expect(action.vacancies.count).to eq(2)
       end
     end
+
+    context 'when params inlcludes unexpected keys' do
+      let(:params) { { page: 2, unexpected_key: 'hello' } }
+
+      it { expect(subject).to be_success }
+    end
   end
 end


### PR DESCRIPTION
### What this PR do?

- updated dry-configurable gem
- added whitelist for http params in index of vacancies action

Closes #2 