### PR TITLE
Flash message after creation of vacancy

### DIFF
--- a/apps/web/controllers/vacancies/create.rb
+++ b/apps/web/controllers/vacancies/create.rb
@@ -17,6 +17,7 @@ module Web
 
           case result
           when Success
+            flash[:success] = 'Вакансия успешно отправлена на модерацию. В ближайшее время она появится на главной.'
             redirect_to routes.root_path
             # TODO: log and trigger rollbar in this case. Also, show new page again
             #

--- a/apps/web/templates/application.html.slim
+++ b/apps/web/templates/application.html.slim
@@ -11,6 +11,9 @@ html
   body.h-100
     main
       .container
+        - if flash[:success]
+          .alert.alert-success
+            = flash[:success]
         = yield
 
     = render partial: 'shared/footer'

--- a/spec/web/controllers/vacancies/create_spec.rb
+++ b/spec/web/controllers/vacancies/create_spec.rb
@@ -57,8 +57,13 @@ RSpec.describe Web::Controllers::Vacancies::Create, type: :action do
 
   context 'when operation returns success result' do
     let(:operation) { ->(*) { Success(Vacancy.new(id: 123)) } }
+    let(:success_flash) { 'Вакансия успешно отправлена на модерацию. В ближайшее время она появится на главной.' }
 
     it { expect(subject).to redirect_to '/' }
+    it 'show flash message' do
+      subject
+      expect(action.exposures[:flash][:success]).to eq(success_flash)
+    end
   end
 
   context 'when operation returns success result' do


### PR DESCRIPTION
### What this PR do?

* added success message to layout
* added displaying message after creation of vacancy

### Screenshots

<img width="1027" alt="Screenshot 2019-05-01 at 22 29 36" src="https://user-images.githubusercontent.com/2529653/57037728-a278d980-6c60-11e9-97aa-031c801f0a53.png">
